### PR TITLE
Add an activity indicator

### DIFF
--- a/Shared code/View/ActivityIndicator.swift
+++ b/Shared code/View/ActivityIndicator.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ActivityIndicator: UIViewRepresentable {
+    @Binding var isAnimating: Bool
+
+    let style: UIActivityIndicatorView.Style
+
+    func makeUIView(context: UIViewRepresentableContext<ActivityIndicator>) -> UIActivityIndicatorView {
+        return UIActivityIndicatorView(style: style)
+    }
+
+    func updateUIView(_ uiView: UIActivityIndicatorView, context: UIViewRepresentableContext<ActivityIndicator>) {
+        isAnimating ? uiView.startAnimating() : uiView.stopAnimating()
+    }
+}

--- a/Shared code/View/LoadingView.swift
+++ b/Shared code/View/LoadingView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct LoadingView<Content>: View where Content: View {
+
+    let isShowing: Bool
+    var content: () -> Content
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .center) {
+
+                self.content()
+                    .disabled(self.isShowing)
+                    .blur(radius: self.isShowing ? 3 : 0)
+
+                VStack {
+                    Text("Loading...")
+                    ActivityIndicator(isAnimating: .constant(true), style: .large)
+                }
+                .frame(width: geometry.size.width / 2,
+                       height: geometry.size.height / 5)
+                .background(Color.secondary.colorInvert())
+                .foregroundColor(Color.primary)
+                .cornerRadius(20)
+                .opacity(self.isShowing ? 1 : 0)
+            }
+        }
+    }
+
+}

--- a/Shared code/ViewModel/WordCampsViewModel.swift
+++ b/Shared code/ViewModel/WordCampsViewModel.swift
@@ -13,10 +13,13 @@ final class WordCampsViewModel<ItemViewModel: EventViewModel>: ObservableObject 
         }
     }
 
+    var isLoading: Bool = true
+
     var objectWillChange = PassthroughSubject<WordCampsViewModel<ItemViewModel>, Never>()
 
     private var wordCampList = WordCampList<ItemViewModel>(events: []) {
         didSet {
+            self.isLoading = wordCampList.eventViewModels.count == 0
             DispatchQueue.main.async {
                 self.objectWillChange.send(self)
             }

--- a/WordCamp/View/ScheduleList.swift
+++ b/WordCamp/View/ScheduleList.swift
@@ -7,12 +7,14 @@ struct ScheduleList: View {
         NavigationView {
             VStack {
                 SearchBar(text: $viewModel.textFilter)
-            List(viewModel.events) { event in
-                NavigationLink(destination: WordCampDetail(event: event)) {
-                    WordCampListView(event: event)
+                LoadingView(isShowing: self.viewModel.isLoading) {
+                    List(self.viewModel.events) { event in
+                        NavigationLink(destination: WordCampDetail(event: event)) {
+                            WordCampListView(event: event)
+                        }
+                    }
+                    .navigationBarTitle(Text("Upcoming WordCamps"))
                 }
-            }
-            .navigationBarTitle(Text("Upcoming WordCamps"))
             }
         }
     }

--- a/WordCamps.xcodeproj/project.pbxproj
+++ b/WordCamps.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		D8113CEE232FECA9004DD6A4 /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8113CED232FECA9004DD6A4 /* RemoteImage.swift */; };
 		D8113CF0232FEDA6004DD6A4 /* RemoteImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8113CEF232FEDA6004DD6A4 /* RemoteImageView.swift */; };
 		D8113CF2232FF0CB004DD6A4 /* CircleImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8113CF1232FF0CB004DD6A4 /* CircleImage.swift */; };
+		D8133547235C0A850028ACD5 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8133546235C0A850028ACD5 /* ActivityIndicator.swift */; };
+		D8133549235C0BCE0028ACD5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8133548235C0BCE0028ACD5 /* LoadingView.swift */; };
 		D824CD582336439C00437CC9 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D824CD572336439C00437CC9 /* SearchBarView.swift */; };
 		D8D42E61235B141A00C4201B /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D8D42E5F235B141A00C4201B /* Interface.storyboard */; };
 		D8D42E63235B141C00C4201B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8D42E62235B141C00C4201B /* Assets.xcassets */; };
@@ -157,6 +159,8 @@
 		D8113CED232FECA9004DD6A4 /* RemoteImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImage.swift; sourceTree = "<group>"; };
 		D8113CEF232FEDA6004DD6A4 /* RemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageView.swift; sourceTree = "<group>"; };
 		D8113CF1232FF0CB004DD6A4 /* CircleImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleImage.swift; sourceTree = "<group>"; };
+		D8133546235C0A850028ACD5 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
+		D8133548235C0BCE0028ACD5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		D824CD572336439C00437CC9 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		D8D42E5D235B141A00C4201B /* WordCampsWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordCampsWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8D42E60235B141A00C4201B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
@@ -259,6 +263,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D8133545235C0A300028ACD5 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				D8133546235C0A850028ACD5 /* ActivityIndicator.swift */,
+				D8133548235C0BCE0028ACD5 /* LoadingView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		D8D42E5E235B141A00C4201B /* WordCampsWatch */ = {
 			isa = PBXGroup;
 			children = (
@@ -349,6 +362,7 @@
 		D8D42ED9235B3F3B00C4201B /* Shared code */ = {
 			isa = PBXGroup;
 			children = (
+				D8133545235C0A300028ACD5 /* View */,
 				D8D42EDD235B3FB700C4201B /* Model */,
 				D8D42EDC235B3F9E00C4201B /* Networking */,
 				D8D42EDB235B3F8000C4201B /* ViewModel */,
@@ -834,6 +848,7 @@
 				D8D7D004232D7B3100687E4B /* Date+WordCamp.swift in Sources */,
 				D8EEA5EA2331A075006C32D0 /* WordCampService.swift in Sources */,
 				D8113CEC232FE28B004DD6A4 /* PhoneEventViewModel.swift in Sources */,
+				D8133547235C0A850028ACD5 /* ActivityIndicator.swift in Sources */,
 				D8D42EBB235B245500C4201B /* EventViewModel.swift in Sources */,
 				D8D7CFDE232D648300687E4B /* ScheduleList.swift in Sources */,
 				D8D7D010232D980A00687E4B /* WordCamp.swift in Sources */,
@@ -846,6 +861,7 @@
 				D8113CF2232FF0CB004DD6A4 /* CircleImage.swift in Sources */,
 				D8EEA5F62331ACC7006C32D0 /* DefaultMediaService.swift in Sources */,
 				D8D7D01D232DA0DB00687E4B /* String+WordCamp.swift in Sources */,
+				D8133549235C0BCE0028ACD5 /* LoadingView.swift in Sources */,
 				D8D7D022232E6DEB00687E4B /* WordCampsViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordCamps.xcodeproj/project.pbxproj
+++ b/WordCamps.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		D8113CF2232FF0CB004DD6A4 /* CircleImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8113CF1232FF0CB004DD6A4 /* CircleImage.swift */; };
 		D8133547235C0A850028ACD5 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8133546235C0A850028ACD5 /* ActivityIndicator.swift */; };
 		D8133549235C0BCE0028ACD5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8133548235C0BCE0028ACD5 /* LoadingView.swift */; };
+		D813354A235C11790028ACD5 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8133546235C0A850028ACD5 /* ActivityIndicator.swift */; };
+		D813354B235C11790028ACD5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8133548235C0BCE0028ACD5 /* LoadingView.swift */; };
 		D824CD582336439C00437CC9 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D824CD572336439C00437CC9 /* SearchBarView.swift */; };
 		D8D42E61235B141A00C4201B /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D8D42E5F235B141A00C4201B /* Interface.storyboard */; };
 		D8D42E63235B141C00C4201B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8D42E62235B141C00C4201B /* Assets.xcassets */; };
@@ -804,9 +806,11 @@
 				D8D42F19235BB7F500C4201B /* TVDetailStack.swift in Sources */,
 				D8D42F05235BB67600C4201B /* RemoteImage.swift in Sources */,
 				D8D42EF7235BB5FD00C4201B /* WordCampsViewModel.swift in Sources */,
+				D813354A235C11790028ACD5 /* ActivityIndicator.swift in Sources */,
 				D8D42F14235BB76900C4201B /* MapView.swift in Sources */,
 				D8D42ECC235B3EB000C4201B /* TVContentView.swift in Sources */,
 				D8D42EFA235BB61100C4201B /* WordCampList.swift in Sources */,
+				D813354B235C11790028ACD5 /* LoadingView.swift in Sources */,
 				D8D42F17235BB79E00C4201B /* TVWordCampDetail.swift in Sources */,
 				D8D42F01235BB61C00C4201B /* PreviewData.swift in Sources */,
 				D8D42EF8235BB60A00C4201B /* WordCampService.swift in Sources */,

--- a/WordCampsTV/TVContentView.swift
+++ b/WordCampsTV/TVContentView.swift
@@ -12,14 +12,16 @@ struct TVContentView: View {
     @ObservedObject var viewModel: WordCampsViewModel<PhoneEventViewModel>
     
     var body: some View {
-        NavigationView {
-            VStack {
-            List(viewModel.events) { event in
-                NavigationLink(destination: TVWordCampDetail(event: event)) {
-                    TVWordCampListView(event: event)
+        LoadingView(isShowing: self.viewModel.isLoading) {
+            NavigationView {
+                VStack {
+                    List(self.viewModel.events) { event in
+                        NavigationLink(destination: TVWordCampDetail(event: event)) {
+                            TVWordCampListView(event: event)
+                        }
+                    }
+                    .navigationBarTitle(Text("Upcoming WordCamps"))
                 }
-            }
-            .navigationBarTitle(Text("Upcoming WordCamps"))
             }
         }
     }


### PR DESCRIPTION
Fixes #8 

<img src="https://user-images.githubusercontent.com/2722505/67154554-d213bf00-f330-11e9-9d8a-64504d9102dc.gif" width="350"/>

Add an activity indicator to iOS, iPadOS and tvOS

## Changes
- UI classes for the activity indicator, and an overlay
- Add logic to the view model to expose when loading is done (this would probably need to be updated when error handling is implemented)

## Testing
- Checkout the branch, run on either iPhone, iPad or Apple TV
- Notice the spinner while loading data. The spinner should get removed when data has finished loading